### PR TITLE
feat: 사용자가 소유한 타이어 정보를 저장

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -986,6 +986,24 @@
         "tar": "^6.1.11"
       }
     },
+    "@nestjs/axios": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.3.tgz",
+      "integrity": "sha512-Cc+D2S2uesthRpalmZEPdm5wF2N9ji4l9Wsb2vFaug/CVWg2BoegHm0L1jzFUL+6kS+mXWSFvwXJmofv+7bajw==",
+      "requires": {
+        "axios": "0.23.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+          "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        }
+      }
+    },
     "@nestjs/cli": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-8.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "0.0.3",
     "@nestjs/common": "^8.0.0",
     "@nestjs/config": "^1.1.3",
     "@nestjs/core": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,7 +4,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { CarsModule } from './cars/cars.module';
 import { UserModule } from './user/user.module';
+import { TiresModule } from './tires/tires.module';
 
 @Module({
   imports: [
@@ -20,6 +22,8 @@ import { UserModule } from './user/user.module';
     }),
     UserModule,
     AuthModule,
+    CarsModule,
+    TiresModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/cars/cars.module.ts
+++ b/src/cars/cars.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserModule } from '../user/user.module';
+import { CarsService } from './cars.service';
+import { Car } from './entities/car.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Car]), UserModule],
+  providers: [CarsService],
+  exports: [CarsService],
+})
+export class CarsModule {}

--- a/src/cars/cars.service.ts
+++ b/src/cars/cars.service.ts
@@ -1,0 +1,37 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserService } from '../user/user.service';
+import { Repository } from 'typeorm';
+import { Car } from './entities/car.entity';
+import { CreateCarDto } from './dto/create-car.dto';
+
+@Injectable()
+export class CarsService {
+  constructor(
+    @InjectRepository(Car) private carsRepository: Repository<Car>,
+    private userService: UserService,
+  ) {}
+
+  async createCar(createCarDto: CreateCarDto, user_id: string): Promise<Car> {
+    const user = await this.userService.findOneByUserId(user_id);
+
+    if (!user) {
+      throw new BadRequestException('해당 유저가 존재하지 않습니다.');
+    }
+
+    const car = this.carsRepository.create({
+      tirm_id: createCarDto.trimId,
+      user,
+    });
+
+    try {
+      return await this.carsRepository.save(car);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+  }
+}

--- a/src/cars/dto/create-car.dto.ts
+++ b/src/cars/dto/create-car.dto.ts
@@ -1,0 +1,6 @@
+import { IsNumber } from 'class-validator';
+
+export class CreateCarDto {
+  @IsNumber()
+  trimId: number;
+}

--- a/src/cars/entities/car.entity.ts
+++ b/src/cars/entities/car.entity.ts
@@ -1,0 +1,23 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+
+@Entity()
+export class Car {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  tirm_id: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @ManyToOne(() => User, (user) => user.cars, { eager: false })
+  user: User;
+}

--- a/src/tires/dto/create-tire.dto.ts
+++ b/src/tires/dto/create-tire.dto.ts
@@ -1,0 +1,9 @@
+import { IsNumber, IsString } from 'class-validator';
+
+export class CreateTireDto {
+  @IsString()
+  userId: string;
+
+  @IsNumber()
+  trimId: number;
+}

--- a/src/tires/entities/tire.entity.ts
+++ b/src/tires/entities/tire.entity.ts
@@ -1,0 +1,40 @@
+import { Car } from '../../cars/entities/car.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity()
+export class Tire {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  front_width: number;
+
+  @Column()
+  front_aspect_ratio: number;
+
+  @Column()
+  front_wheel_size: number;
+
+  @Column()
+  rear_width: number;
+
+  @Column()
+  rear_aspect_ratio: number;
+
+  @Column()
+  rear_wheel_size: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @OneToOne(() => Car)
+  @JoinColumn()
+  car: Car;
+}

--- a/src/tires/tires.controller.ts
+++ b/src/tires/tires.controller.ts
@@ -1,0 +1,28 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  ParseArrayPipe,
+  Post,
+} from '@nestjs/common';
+import { CreateTireDto } from './dto/create-tire.dto';
+import { Tire } from './entities/tire.entity';
+import { TiresService } from './tires.service';
+
+@Controller('tires')
+export class TiresController {
+  constructor(private readonly tiresService: TiresService) {}
+  @Post()
+  async createTires(
+    @Body(new ParseArrayPipe({ items: CreateTireDto }))
+    createTireDtos: CreateTireDto[],
+  ): Promise<Tire[]> {
+    if (createTireDtos.length > 5 || createTireDtos.length === 0) {
+      throw new BadRequestException(
+        '입력된 데이터가 5개를 초과하거나 없습니다.',
+      );
+    }
+
+    return this.tiresService.createTires(createTireDtos);
+  }
+}

--- a/src/tires/tires.module.ts
+++ b/src/tires/tires.module.ts
@@ -1,0 +1,21 @@
+import { HttpModule } from '@nestjs/axios';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CarsModule } from 'src/cars/cars.module';
+import { Tire } from './entities/tire.entity';
+import { TiresController } from './tires.controller';
+import { TiresService } from './tires.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Tire]),
+    HttpModule.register({
+      timeout: 5000,
+      maxRedirects: 5,
+    }),
+    CarsModule,
+  ],
+  controllers: [TiresController],
+  providers: [TiresService],
+})
+export class TiresModule {}

--- a/src/tires/tires.service.ts
+++ b/src/tires/tires.service.ts
@@ -1,0 +1,111 @@
+import { HttpService } from '@nestjs/axios';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CarsService } from '../cars/cars.service';
+import { Connection, Repository } from 'typeorm';
+import { CreateTireDto } from './dto/create-tire.dto';
+import { Tire } from './entities/tire.entity';
+
+@Injectable()
+export class TiresService {
+  constructor(
+    @InjectRepository(Tire) private tiresRepository: Repository<Tire>,
+    private httpService: HttpService,
+    private carsService: CarsService,
+    private connection: Connection,
+  ) {}
+  async createTires(createTireDtos: CreateTireDto[]): Promise<Tire[]> {
+    const createdTireList: Tire[] = [];
+    for (const createTireDto of createTireDtos) {
+      const { userId, trimId } = createTireDto;
+      const { frontTire, rearTire } = await this.getTireInfoAPI(trimId);
+      const frontTireInfo = this.convertTireInfo(frontTire);
+      const rearTireInfo = this.convertTireInfo(rearTire);
+
+      createdTireList.push(
+        await this.createTireTransactions(
+          trimId,
+          userId,
+          frontTireInfo,
+          rearTireInfo,
+        ),
+      );
+    }
+    return createdTireList;
+  }
+
+  private async createTireTransactions(
+    trimId: number,
+    userId: string,
+    frontTireInfo: { width: number; aspectRatio: number; wheelSize: number },
+    rearTireInfo: { width: number; aspectRatio: number; wheelSize: number },
+  ): Promise<Tire> {
+    const queryRunner = this.connection.createQueryRunner();
+
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      const car = await this.carsService.createCar({ trimId }, userId);
+
+      const tire = this.tiresRepository.create({
+        front_width: frontTireInfo.width,
+        front_aspect_ratio: frontTireInfo.aspectRatio,
+        front_wheel_size: frontTireInfo.wheelSize,
+        rear_width: rearTireInfo.width,
+        rear_aspect_ratio: rearTireInfo.aspectRatio,
+        rear_wheel_size: rearTireInfo.wheelSize,
+        car: car,
+      });
+
+      const resultTireData = await this.tiresRepository.save(tire);
+
+      await queryRunner.commitTransaction();
+      return resultTireData;
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      throw new BadRequestException(
+        `${err} - userId : ${userId} / trimId: ${trimId}`,
+      );
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async getTireInfoAPI(trimId: number): Promise<any> {
+    const url = `https://dev.mycar.cardoc.co.kr/v1/trim/${trimId}`;
+    return await this.httpService
+      .get(url)
+      .toPromise()
+      .then((API_DATA) => {
+        const frontTire = API_DATA.data.spec.driving.frontTire.value;
+        const rearTire = API_DATA.data.spec.driving.rearTire.value;
+
+        return { frontTire, rearTire };
+      })
+      .catch(() => {
+        throw new BadRequestException(
+          `올바르지 않은 차량 번호 입니다. - ${trimId} `,
+        );
+      });
+  }
+
+  convertTireInfo(tireInfo: string): {
+    width: number;
+    aspectRatio: number;
+    wheelSize: number;
+  } {
+    if (tireInfo.search(/^[0-9]{3}\/[0-9]{2}R[0-9]{2}/g) == -1) {
+      throw new InternalServerErrorException(
+        `올바르지 않은 포맷 입니다. - ${tireInfo}`,
+      );
+    }
+    const [width, aspectRatio, wheelSize] = tireInfo
+      .split(/\/|\D/)
+      .map((num) => parseInt(num));
+    return { width, aspectRatio, wheelSize };
+  }
+}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -3,10 +3,12 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { InternalServerErrorException } from '@nestjs/common';
+import { Car } from 'src/cars/entities/car.entity';
 
 @Entity()
 export class User {
@@ -24,6 +26,9 @@ export class User {
 
   @Column({ type: 'datetime', nullable: true })
   logined_at: Date;
+
+  @OneToMany(() => Car, (car) => car.id, { eager: false })
+  cars: Car[];
 
   @BeforeInsert()
   async hashPassword(): Promise<void> {


### PR DESCRIPTION


## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩터링
- [ ] 테스트

## 작업 개요
- 사용자가 소유한 타이어 정보를 저장

## 상세 내용
- 유저 소유 자동차 저장
- 타이어 정보 조회 외부 API 사용
- 외부 API 데이터 검증
- 트랜잭션을 사용
- car / tire 엔티티 작성

resolve : #6 #7
